### PR TITLE
Fix memory corruption in da_hex

### DIFF
--- a/p2com.asm
+++ b/p2com.asm
@@ -14586,6 +14586,7 @@ da_addr:	mov	[byte edi],'$'	;print '$'
 da_hex:		shl	cl,2		;get first nibble into position
 		ror	eax,cl
 		shr	cl,2
+		and ecx,255
 
 @@digit:	rol	eax,4		;print hex digits
 		push	eax


### PR DESCRIPTION
All call sites just set CL, but LOOP operates on the entirety of ECX, so if the high 24 bits of the register don't happen to be zero, `da_hex` will corrupt memory.